### PR TITLE
Fixes `sed -i` on OS X.

### DIFF
--- a/bin/certified-crt
+++ b/bin/certified-crt
@@ -50,7 +50,8 @@ then die "private key $NAME.key already does not exist"
 fi
 
 if [ -z "$SELF_SIGNED" ]
-then sed -i "s/#authorityKeyIdentifier/authorityKeyIdentifier/" "$NAME.cnf"
+then sed -i.bak "s/#authorityKeyIdentifier/authorityKeyIdentifier/" "$NAME.cnf"
+rm "$NAME.cnf.bak"
 fi
 
 if [ "$SELF_SIGNED" ]


### PR DESCRIPTION
Using `sed -i.bak` instead of `sed -i` which works for both BSD an GNU
versions of `sed`.

`make test` now passes on both OS X and GNU/Linux.
Fixes #5.
