### PR TITLE
Configurable path length for CAs

### DIFF
--- a/bin/certified
+++ b/bin/certified
@@ -12,6 +12,7 @@
 #/   --name=<name>               filename to use (default derived from the certificate common name)
 #/   --no-sign                   do not sign the certificate; stop with a certificate signing request
 #/   --password=<password>       password for the private key (implies --encrypt)
+#/   --pathlen=<sub CAs>         Number of children CAs that can be issued under this CA, -1 to disable, default 1
 #/   --revoke                    revoke an existing certificate
 #/   --self-signed               generate a self-signed certificate instead of using the CA
 #/   C=<country>                 certificate country (defaults to the CA country)
@@ -49,6 +50,8 @@ do
         --no-sign) NO_SIGN="--no-sign" shift;;
         --password) PASSWORD="$2" shift 2;;
         --password=*) PASSWORD="$(echo "$1" | cut -d"=" -f"2-")" shift;;
+        --pathlen) PATHLEN="$2" shift 2;;
+        --pathlen=*) PATHLEN="$(echo "$1" | cut -d"=" -f"2-")" shift;;
         --revoke) REVOKE="--revoke" shift;;
         --self|--self-sign|--self-signed) SELF_SIGNED="--self-signed" shift;;
 		-h|--help) usage 0;;
@@ -82,7 +85,11 @@ then
     exit
 fi
 
-certified-csr --bits="$BITS" $CA --days="$DAYS" --db="." $ENCRYPT --issuer="$ISSUER" --issuer-name="$ISSUER_NAME" --name="$NAME" --password="$PASSWORD" C="$C" CN="$CN" L="$L" O="$O" ST="$ST" $SAN
+if [ -z "$PATHLEN" ]
+then PATHLEN="1"
+fi
+
+certified-csr --bits="$BITS" $CA --pathlen="$PATHLEN" --days="$DAYS" --db="." $ENCRYPT --issuer="$ISSUER" --issuer-name="$ISSUER_NAME" --name="$NAME" --password="$PASSWORD" C="$C" CN="$CN" L="$L" O="$O" ST="$ST" $SAN
 
 if [ -z "$NO_SIGN" ]
 then certified-crt --days="$DAYS" --db="." --name="$NAME" --ca-password="$CA_PASSWORD" $SELF_SIGNED CN="$CN"

--- a/bin/certified-ca
+++ b/bin/certified-ca
@@ -11,6 +11,7 @@
 #/   --root-password=<root-password>                 password for the root CA private key
 #/   --revoke                                        revoke an intermediate CA certificate
 #/   --root-crl-url=<root-crl-url>                   CRL distribution URL for the root CA
+#/   --pathlen=<sub CAs>                             Number of children CAs that can be issued under this CA, -1 to disable, default 1
 #/   C=<country>                                     certificate country
 #/   ST=<state>                                      certificate state (optional)
 #/   L=<locality>                                    certificate locality (usually a city)
@@ -37,6 +38,8 @@ do
         --intermediate-password=*) INTERMEDIATE_PASSWORD="$(echo "$1" | cut -d"=" -f"2-")" shift;;
         --ocsp-url) OCSP_URL="$2" shift 2;;
         --ocsp-url=*) OCSP_URL="$(echo "$1" | cut -d"=" -f"2-")" shift;;
+        --pathlen) PATHLEN="$2" shift 2;;
+        --pathlen=*) PATHLEN="$(echo "$1" | cut -d"=" -f"2-")" shift;;
         --revoke) REVOKE="--revoke" shift;;
         --root-crl-url) ROOT_CRL_URL="$2" shift 2;;
         --root-crl-url=*) ROOT_CRL_URL="$(echo "$1" | cut -d"=" -f"2-")" shift;;
@@ -84,6 +87,13 @@ if [ ! -f "root-ca.db.serial" ]
 then echo "01" >"root-ca.db.serial"
 fi
 
+if [ -z "$PATHLEN" ]
+then PATHLEN="1"
+fi
+if [ "$PATHLEN" != "-1" ]
+then PATHLEN_STR=", pathlen:$PATHLEN"
+fi
+
 {
     cat <<EOF
 : \${BITS:="$BITS"}
@@ -129,7 +139,7 @@ prompt = no
 
 [x509_extensions]
 EOF
-    echo "basicConstraints = critical, CA:TRUE, pathlen:1"
+    echo "basicConstraints = critical, CA:TRUE $PATHLEN_STR"
     cat <<EOF
 keyUsage = critical, cRLSign, keyCertSign, nonRepudiation
 subjectKeyIdentifier = hash

--- a/bin/certified-csr
+++ b/bin/certified-csr
@@ -12,6 +12,7 @@
 #/   --name=<name>               filename to use (default derived from the certificate common name)
 #/   --ocsp-url=<ocsp-url>       OCSP responder URL
 #/   --password=<password>       password for the private key (implies --encrypt)
+#/   --pathlen=<sub CAs>         Number of children CAs that can be issued under this CA, -1 to disable, default 1
 #/   C=<country>                 certificate country (defaults to the CA country)
 #/   ST=<state>                  certificate state (defaults to the CA state)
 #/   L=<locality>                certificate locality (usually a city; defaults to the CA locality)
@@ -49,6 +50,8 @@ do
         --ocsp-url=*) OCSP_URL="$(echo "$1" | cut -d"=" -f"2-")" shift;;
         --password) PASSWORD="$2" shift 2;;
         --password=*) PASSWORD="$(echo "$1" | cut -d"=" -f"2-")" shift;;
+        --pathlen) PATHLEN="$2" shift 2;;
+        --pathlen=*) PATHLEN="$(echo "$1" | cut -d"=" -f"2-")" shift;;
 		-h|--help) usage 0;;
 		-*) usage 1;;
         C=*) C="$(echo "$1" | cut -d"=" -f"2-")" shift;;
@@ -94,6 +97,13 @@ fi
 touch "$ISSUER_NAME.db" "$ISSUER_NAME.db.attr"
 if [ ! -f "$ISSUER_NAME.db.serial" ]
 then echo "01" >"$ISSUER_NAME.db.serial"
+fi
+
+if [ -z "$PATHLEN" ]
+then PATHLEN="1"
+fi
+if [ "$PATHLEN" != "-1" ]
+then PATHLEN_STR=", pathlen:$PATHLEN"
 fi
 
 log "configuring OpenSSL"
@@ -164,7 +174,7 @@ EOF
     if_echo "$OCSP_URL" "authorityInfoAccess = OCSP;URI:$OCSP_URL"
     echo "#authorityKeyIdentifier = keyid:always, issuer:always"
     if [ "$CA" ]
-    then echo "basicConstraints = critical, CA:TRUE, pathlen:0"
+    then echo "basicConstraints = critical, CA:TRUE $PATHLEN_STR"
     else echo "basicConstraints = critical, CA:FALSE"
     fi
     if_echo "$CRL_URL" "crlDistributionPoints = URI:$CRL_URL"


### PR DESCRIPTION
If you need CAs under the intermediate you need this to relieve the constraint on the root ca.
