### PR TITLE
Add support for adding any SAN identifier

### DIFF
--- a/bin/certified-csr
+++ b/bin/certified-csr
@@ -20,6 +20,7 @@
 #/   CN=<common-name>            certificate common name (usually a domain name)
 #/   +<dns>                      add a DNS name to the certificate's subject alternative names
 #/   +<ip>                       add an IP address to the certificate's subject alternative names
+#/   +<ID>:<value>               add any x509 SAN property, useful for RID, URI, email, etc
 
 set -e
 
@@ -27,6 +28,7 @@ set -e
 
 SAN_DNS=""
 SAN_IP=""
+SAN_ID=""
 while [ "$#" -gt 0 ]
 do
     case "$1" in
@@ -60,7 +62,9 @@ do
         ST=*) ST="$(echo "$1" | cut -d"=" -f"2-")" shift;;
         +*)
             SAN="$(echo "$1" | cut -c"2-")" shift
-            if is_ip "$SAN"
+            if is_san_id "$SAN"
+            then SAN_ID="$SAN_ID $SAN"
+            elif is_ip "$SAN"
             then SAN_IP="$SAN_IP $SAN"
             elif is_dns "$SAN"
             then SAN_DNS="$SAN_DNS $SAN"
@@ -142,7 +146,7 @@ default_md = sha256
 distinguished_name = dn
 prompt = no
 EOF
-    if [ "$SAN_DNS" -o "$SAN_IP" ]
+    if [ "$SAN_DNS" -o "$SAN_IP" -o "$SAN_ID" ]
     then cat <<EOF
 
 [san]
@@ -158,6 +162,14 @@ EOF
     for IP in $SAN_IP
     do
         echo "IP.$I = $IP"
+        I=$(($I + 1))
+    done
+    I=1
+    for SID in $SAN_ID
+    do
+        ID="$(echo "$SID" | cut -f1 -d":")"
+        VAL="$(echo "$SID" | cut -f2- -d":")"
+        echo "$ID.$I = $VAL"
         I=$(($I + 1))
     done
     cat <<EOF

--- a/lib/certified.sh
+++ b/lib/certified.sh
@@ -54,6 +54,11 @@ is_ip() {
     echo "$1" | grep -E -q "([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]).([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]).([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]).([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])"
 }
 
+# Return zero if the first characters represents a valid looking SAN identifier
+is_san_id() {
+    echo "$1" | grep -E -q "^[a-zA-Z0-9]+:.*"
+}
+
 # Log a message to stderr, in bold and prefixed with "certified: ".
 log() {
     echo "$(tput "bold")$(basename "$0"): $*$(tput "sgr0")" >&2

--- a/share/html/certified-ca.1.html
+++ b/share/html/certified-ca.1.html
@@ -81,7 +81,7 @@
 
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>certified-ca</code> [<code>--bits</code>=<em>bits</em>] [<code>--crl-url</code>=<em>crl-url</em>] [<code>--days</code>=<em>days</em>] [<code>--db</code>=<em>db</em>] [<code>--encrypt-intermediate</code>] [<code>--intermediate-password</code>=<em>intermediate-password</em>] [<code>--ocsp-url</code>=<em>ocsp-url</em>] [<code>--revoke</code>] [<code>--root-crl-url</code>=<em>root-crl-url</em>] [<code>--root-password</code>=<em>root-password</em>] [<code>OU</code>=<em>org-unit</em>] <code>C</code>=<em>country</em> <code>ST</code>=<em>state</em> <code>L</code>=<em>locality</em> <code>O</code>=<em>organization</em> <code>CN</code>=<em>common-name</em></p>
+<p><code>certified-ca</code> [<code>--bits</code>=<em>bits</em>] [<code>--crl-url</code>=<em>crl-url</em>] [<code>--days</code>=<em>days</em>] [<code>--db</code>=<em>db</em>] [<code>--encrypt-intermediate</code>] [<code>--intermediate-password</code>=<em>intermediate-password</em>] [<code>--ocsp-url</code>=<em>ocsp-url</em>] [<code>--revoke</code>] [<code>--root-crl-url</code>=<em>root-crl-url</em>] [<code>--root-password</code>=<em>root-password</em>] [<code>OU</code>=<em>org-unit</em>] <code>C</code>=<em>country</em> <code>ST</code>=<em>state</em> <code>L</code>=<em>locality</em> <code>O</code>=<em>organization</em> <code>CN</code>=<em>common-name</em> [<code>+</code><em>dns</em>[<em>...</em>]] [<code>+</code><em>ip</em>[<em>...</em>]] [<code>+</code><em>id</em>:<em>value</em>[<em>...</em>]]</p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
@@ -109,6 +109,7 @@
 <dt><code>OU</code>=<em>org-unit</em></dt><dd>Certificate organizational unit (usually a department or group).</dd>
 <dt><code>CN</code>=<em>common-name</em></dt><dd>Certificate common name (usually a domain name or <em>Company CA</em>).</dd>
 <dt><code>+</code><em>dns</em>, <code>+</code><em>ip</em></dt><dd>Add a DNS name or IP address to the certificate's subject alternative names.</dd>
+<dt><code>+</code><em>id</em>:<em>value</em></dt><dd>Add any SAN field to the certificate's subject alternative names, ie: URI:mailto:nobody@example.com.</dd>
 </dl>
 
 
@@ -118,7 +119,7 @@
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Richard Crowley &lt;<a href="&#109;&#x61;&#105;&#x6c;&#x74;&#111;&#x3a;&#114;&#64;&#114;&#99;&#114;&#x6f;&#x77;&#x6c;&#x65;&#x79;&#x2e;&#111;&#114;&#103;" data-bare-link="true">&#114;&#64;&#x72;&#99;&#x72;&#x6f;&#x77;&#108;&#101;&#x79;&#46;&#111;&#x72;&#103;</a>></p>
+<p>Richard Crowley &lt;<a href="&#x6d;&#x61;&#105;&#108;&#x74;&#111;&#x3a;&#x72;&#64;&#114;&#x63;&#x72;&#111;&#x77;&#x6c;&#x65;&#121;&#46;&#x6f;&#114;&#103;" data-bare-link="true">&#114;&#x40;&#114;&#99;&#114;&#x6f;&#x77;&#x6c;&#101;&#121;&#46;&#111;&#114;&#103;</a>></p>
 
 <h2 id="SEE-ALSO">SEE ALSO</h2>
 
@@ -133,7 +134,7 @@
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>October 2015</li>
+    <li class='tc'>January 2017</li>
     <li class='tr'>certified-ca(1)</li>
   </ol>
 

--- a/share/html/certified-csr.1.html
+++ b/share/html/certified-csr.1.html
@@ -81,7 +81,7 @@
 
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>certified-csr</code> [<code>--bits</code>=<em>bits</em>] [<code>--ca</code>] [<code>--crl-url</code>=<em>crl-url</em>] [<code>--days</code>=<em>days</em>] [<code>--db</code>=<em>db</em>] [<code>--encrypt</code>] [<code>--issuer</code>=<em>issuer</em>] [<code>--issuer-name</code>=<em>issuer-name</em>] [<code>--name</code>=<em>name</em>] [<code>--ocsp-url</code>=<em>ocsp-url</em>] [<code>--password</code>=<em>password</em>] [<code>C</code>=<em>country</em>] [<code>ST</code>=<em>state</em>] [<code>L</code>=<em>locality</em>] [<code>O</code>=<em>organization</em>] [<code>OU</code>=<em>org-unit</em>] <code>CN</code>=<em>common-name</em> [<code>+</code><em>dns</em>[<em>...</em>]] [<code>+</code><em>ip</em>[<em>...</em>]]</p>
+<p><code>certified-csr</code> [<code>--bits</code>=<em>bits</em>] [<code>--ca</code>] [<code>--crl-url</code>=<em>crl-url</em>] [<code>--days</code>=<em>days</em>] [<code>--db</code>=<em>db</em>] [<code>--encrypt</code>] [<code>--issuer</code>=<em>issuer</em>] [<code>--issuer-name</code>=<em>issuer-name</em>] [<code>--name</code>=<em>name</em>] [<code>--ocsp-url</code>=<em>ocsp-url</em>] [<code>--password</code>=<em>password</em>] [<code>C</code>=<em>country</em>] [<code>ST</code>=<em>state</em>] [<code>L</code>=<em>locality</em>] [<code>O</code>=<em>organization</em>] [<code>OU</code>=<em>org-unit</em>] <code>CN</code>=<em>common-name</em> [<code>+</code><em>dns</em>[<em>...</em>]] [<code>+</code><em>ip</em>[<em>...</em>]] [<code>+</code><em>id</em>:<em>value</em>[<em>...</em>]]</p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
@@ -110,6 +110,7 @@
 <dt><code>OU</code>=<em>org-unit</em></dt><dd>Certificate organizational unit (usually a department or group; defaults to the CA organizational unit).</dd>
 <dt><code>CN</code>=<em>common-name</em></dt><dd>Certificate common name (usually a domain name).</dd>
 <dt><code>+</code><em>dns</em>, <code>+</code><em>ip</em></dt><dd>Add a DNS name or IP address to the certificate's subject alternative names.</dd>
+<dt><code>+</code><em>id</em>:<em>value</em></dt><dd>Add any SAN field to the certificate's subject alternative names, ie: URI:mailto:nobody@example.com.</dd>
 </dl>
 
 
@@ -119,7 +120,7 @@
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Richard Crowley &lt;<a href="&#109;&#x61;&#105;&#x6c;&#x74;&#111;&#x3a;&#114;&#64;&#114;&#99;&#114;&#x6f;&#x77;&#x6c;&#x65;&#x79;&#x2e;&#111;&#114;&#103;" data-bare-link="true">&#114;&#64;&#x72;&#99;&#x72;&#x6f;&#x77;&#108;&#101;&#x79;&#46;&#111;&#x72;&#103;</a>></p>
+<p>Richard Crowley &lt;<a href="&#109;&#97;&#105;&#x6c;&#x74;&#x6f;&#58;&#114;&#x40;&#114;&#x63;&#114;&#x6f;&#119;&#x6c;&#101;&#121;&#46;&#x6f;&#114;&#103;" data-bare-link="true">&#114;&#x40;&#x72;&#x63;&#x72;&#111;&#x77;&#108;&#x65;&#x79;&#46;&#x6f;&#x72;&#x67;</a>></p>
 
 <h2 id="SEE-ALSO">SEE ALSO</h2>
 
@@ -134,7 +135,7 @@
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>October 2015</li>
+    <li class='tc'>January 2017</li>
     <li class='tr'>certified-csr(1)</li>
   </ol>
 

--- a/share/html/certified.1.html
+++ b/share/html/certified.1.html
@@ -81,7 +81,7 @@
 
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>certified</code> [<code>--bits</code>=<em>bits</em>] [<code>--ca</code>] [<code>--ca-password</code>=<em>ca-password</em>] [<code>--days</code>=<em>days</em>] [<code>--db</code>=<em>db</em>] [<code>--encrypt</code>] [<code>--issuer</code>=<em>issuer</em>] [<code>--issuer-name</code>=<em>issuer-name</em>] [<code>--name</code>=<em>name</em>] [<code>--no-sign</code>] [<code>--password</code>=<em>password</em>] [<code>--revoke</code>] [<code>--self-signed</code>] [<code>C</code>=<em>country</em>] [<code>ST</code>=<em>state</em>] [<code>L</code>=<em>locality</em>] [<code>O</code>=<em>organization</em>] [<code>OU</code>=<em>org-unit</em>] <code>CN</code>=<em>common-name</em> [<code>+</code><em>dns</em>[<em>...</em>]] [<code>+</code><em>ip</em>[<em>...</em>]]</p>
+<p><code>certified</code> [<code>--bits</code>=<em>bits</em>] [<code>--ca</code>] [<code>--ca-password</code>=<em>ca-password</em>] [<code>--days</code>=<em>days</em>] [<code>--db</code>=<em>db</em>] [<code>--encrypt</code>] [<code>--issuer</code>=<em>issuer</em>] [<code>--issuer-name</code>=<em>issuer-name</em>] [<code>--name</code>=<em>name</em>] [<code>--no-sign</code>] [<code>--password</code>=<em>password</em>] [<code>--revoke</code>] [<code>--self-signed</code>] [<code>C</code>=<em>country</em>] [<code>ST</code>=<em>state</em>] [<code>L</code>=<em>locality</em>] [<code>O</code>=<em>organization</em>] [<code>OU</code>=<em>org-unit</em>] <code>CN</code>=<em>common-name</em> [<code>+</code><em>dns</em>[<em>...</em>]] [<code>+</code><em>ip</em>[<em>...</em>]] [<code>+</code><em>id</em>:<em>value</em>[<em>...</em>]]</p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
@@ -112,6 +112,7 @@
 <dt><code>OU</code>=<em>org-unit</em></dt><dd>Certificate organizational unit (usually a department or group; defaults to the CA organizational unit).</dd>
 <dt><code>CN</code>=<em>common-name</em></dt><dd>Certificate common name (usually a domain name).</dd>
 <dt><code>+</code><em>dns</em>, <code>+</code><em>ip</em></dt><dd>Add a DNS name or IP address to the certificate's subject alternative names.</dd>
+<dt><code>+</code><em>id</em>:<em>value</em></dt><dd>Add any SAN field to the certificate's subject alternative names, ie: URI:mailto:nobody@example.com.</dd>
 </dl>
 
 
@@ -121,7 +122,7 @@
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Richard Crowley &lt;<a href="&#109;&#x61;&#105;&#x6c;&#x74;&#111;&#x3a;&#114;&#64;&#114;&#99;&#114;&#x6f;&#x77;&#x6c;&#x65;&#x79;&#x2e;&#111;&#114;&#103;" data-bare-link="true">&#114;&#64;&#x72;&#99;&#x72;&#x6f;&#x77;&#108;&#101;&#x79;&#46;&#111;&#x72;&#103;</a>></p>
+<p>Richard Crowley &lt;<a href="&#x6d;&#x61;&#105;&#108;&#x74;&#111;&#x3a;&#x72;&#64;&#114;&#x63;&#x72;&#111;&#x77;&#x6c;&#x65;&#121;&#46;&#x6f;&#114;&#103;" data-bare-link="true">&#114;&#x40;&#114;&#99;&#114;&#x6f;&#x77;&#x6c;&#101;&#121;&#46;&#111;&#114;&#103;</a>></p>
 
 <h2 id="SEE-ALSO">SEE ALSO</h2>
 
@@ -136,7 +137,7 @@
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>October 2015</li>
+    <li class='tc'>January 2017</li>
     <li class='tr'>certified(1)</li>
   </ol>
 

--- a/share/man/man1/certified-ca.1
+++ b/share/man/man1/certified-ca.1
@@ -1,13 +1,13 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "CERTIFIED\-CA" "1" "October 2015" "" "Certified"
+.TH "CERTIFIED\-CA" "1" "January 2017" "" "Certified"
 .
 .SH "NAME"
 \fBcertified\-ca\fR \- generate a CA
 .
 .SH "SYNOPSIS"
-\fBcertified\-ca\fR [\fB\-\-bits\fR=\fIbits\fR] [\fB\-\-crl\-url\fR=\fIcrl\-url\fR] [\fB\-\-days\fR=\fIdays\fR] [\fB\-\-db\fR=\fIdb\fR] [\fB\-\-encrypt\-intermediate\fR] [\fB\-\-intermediate\-password\fR=\fIintermediate\-password\fR] [\fB\-\-ocsp\-url\fR=\fIocsp\-url\fR] [\fB\-\-revoke\fR] [\fB\-\-root\-crl\-url\fR=\fIroot\-crl\-url\fR] [\fB\-\-root\-password\fR=\fIroot\-password\fR] [\fBOU\fR=\fIorg\-unit\fR] \fBC\fR=\fIcountry\fR \fBST\fR=\fIstate\fR \fBL\fR=\fIlocality\fR \fBO\fR=\fIorganization\fR \fBCN\fR=\fIcommon\-name\fR
+\fBcertified\-ca\fR [\fB\-\-bits\fR=\fIbits\fR] [\fB\-\-crl\-url\fR=\fIcrl\-url\fR] [\fB\-\-days\fR=\fIdays\fR] [\fB\-\-db\fR=\fIdb\fR] [\fB\-\-encrypt\-intermediate\fR] [\fB\-\-intermediate\-password\fR=\fIintermediate\-password\fR] [\fB\-\-ocsp\-url\fR=\fIocsp\-url\fR] [\fB\-\-revoke\fR] [\fB\-\-root\-crl\-url\fR=\fIroot\-crl\-url\fR] [\fB\-\-root\-password\fR=\fIroot\-password\fR] [\fBOU\fR=\fIorg\-unit\fR] \fBC\fR=\fIcountry\fR \fBST\fR=\fIstate\fR \fBL\fR=\fIlocality\fR \fBO\fR=\fIorganization\fR \fBCN\fR=\fIcommon\-name\fR [\fB+\fR\fIdns\fR[\fI\.\.\.\fR]] [\fB+\fR\fIip\fR[\fI\.\.\.\fR]] [\fB+\fR\fIid\fR:\fIvalue\fR[\fI\.\.\.\fR]]
 .
 .SH "DESCRIPTION"
 Generate two private keys\. The first is self\-signed to generate the root CA certificate\. It is then used to sign the second to generate the intermediate CA certificate\. The root CA certificate should be installed on laptops and servers\. The intermediate CA signs subsequent certificates and may itself be revoked in the event its private key is compromised\.
@@ -84,6 +84,10 @@ Certificate common name (usually a domain name or \fICompany CA\fR)\.
 .TP
 \fB+\fR\fIdns\fR, \fB+\fR\fIip\fR
 Add a DNS name or IP address to the certificate\'s subject alternative names\.
+.
+.TP
+\fB+\fR\fIid\fR:\fIvalue\fR
+Add any SAN field to the certificate\'s subject alternative names, ie: URI:mailto:nobody@example\.com\.
 .
 .SH "THEME SONG"
 Led Zeppelin \- "Fool in the Rain"

--- a/share/man/man1/certified-ca.1.ronn
+++ b/share/man/man1/certified-ca.1.ronn
@@ -2,7 +2,7 @@
 
 ## SYNOPSIS
 
-`certified-ca` [`--bits`=_bits_] [`--crl-url`=_crl-url_] [`--days`=_days_] [`--db`=_db_] [`--encrypt-intermediate`] [`--intermediate-password`=_intermediate-password_] [`--ocsp-url`=_ocsp-url_] [`--revoke`] [`--root-crl-url`=_root-crl-url_] [`--root-password`=_root-password_] [`OU`=_org-unit_] `C`=_country_ `ST`=_state_ `L`=_locality_ `O`=_organization_ `CN`=_common-name_
+`certified-ca` [`--bits`=_bits_] [`--crl-url`=_crl-url_] [`--days`=_days_] [`--db`=_db_] [`--encrypt-intermediate`] [`--intermediate-password`=_intermediate-password_] [`--ocsp-url`=_ocsp-url_] [`--revoke`] [`--root-crl-url`=_root-crl-url_] [`--root-password`=_root-password_] [`OU`=_org-unit_] `C`=_country_ `ST`=_state_ `L`=_locality_ `O`=_organization_ `CN`=_common-name_ [`+`_dns_[_..._]] [`+`_ip_[_..._]] [`+`_id_:_value_[_..._]]
 
 ## DESCRIPTION
 
@@ -46,6 +46,8 @@ _db_ is an OpenSSL database that `certified`(1) uses to issue and revoke certifi
   Certificate common name (usually a domain name or _Company CA_).
 * `+`_dns_, `+`_ip_:
   Add a DNS name or IP address to the certificate's subject alternative names.
+* `+`_id_:_value_:
+  Add any SAN field to the certificate's subject alternative names, ie: URI:mailto:nobody@example.com.
 
 ## THEME SONG
 

--- a/share/man/man1/certified-csr.1
+++ b/share/man/man1/certified-csr.1
@@ -1,13 +1,13 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "CERTIFIED\-CSR" "1" "October 2015" "" "Certified"
+.TH "CERTIFIED\-CSR" "1" "January 2017" "" "Certified"
 .
 .SH "NAME"
 \fBcertified\-csr\fR \- generate certificate signing requests
 .
 .SH "SYNOPSIS"
-\fBcertified\-csr\fR [\fB\-\-bits\fR=\fIbits\fR] [\fB\-\-ca\fR] [\fB\-\-crl\-url\fR=\fIcrl\-url\fR] [\fB\-\-days\fR=\fIdays\fR] [\fB\-\-db\fR=\fIdb\fR] [\fB\-\-encrypt\fR] [\fB\-\-issuer\fR=\fIissuer\fR] [\fB\-\-issuer\-name\fR=\fIissuer\-name\fR] [\fB\-\-name\fR=\fIname\fR] [\fB\-\-ocsp\-url\fR=\fIocsp\-url\fR] [\fB\-\-password\fR=\fIpassword\fR] [\fBC\fR=\fIcountry\fR] [\fBST\fR=\fIstate\fR] [\fBL\fR=\fIlocality\fR] [\fBO\fR=\fIorganization\fR] [\fBOU\fR=\fIorg\-unit\fR] \fBCN\fR=\fIcommon\-name\fR [\fB+\fR\fIdns\fR[\fI\.\.\.\fR]] [\fB+\fR\fIip\fR[\fI\.\.\.\fR]]
+\fBcertified\-csr\fR [\fB\-\-bits\fR=\fIbits\fR] [\fB\-\-ca\fR] [\fB\-\-crl\-url\fR=\fIcrl\-url\fR] [\fB\-\-days\fR=\fIdays\fR] [\fB\-\-db\fR=\fIdb\fR] [\fB\-\-encrypt\fR] [\fB\-\-issuer\fR=\fIissuer\fR] [\fB\-\-issuer\-name\fR=\fIissuer\-name\fR] [\fB\-\-name\fR=\fIname\fR] [\fB\-\-ocsp\-url\fR=\fIocsp\-url\fR] [\fB\-\-password\fR=\fIpassword\fR] [\fBC\fR=\fIcountry\fR] [\fBST\fR=\fIstate\fR] [\fBL\fR=\fIlocality\fR] [\fBO\fR=\fIorganization\fR] [\fBOU\fR=\fIorg\-unit\fR] \fBCN\fR=\fIcommon\-name\fR [\fB+\fR\fIdns\fR[\fI\.\.\.\fR]] [\fB+\fR\fIip\fR[\fI\.\.\.\fR]] [\fB+\fR\fIid\fR:\fIvalue\fR[\fI\.\.\.\fR]]
 .
 .SH "DESCRIPTION"
 Generate a certificate signing request\.
@@ -88,6 +88,10 @@ Certificate common name (usually a domain name)\.
 .TP
 \fB+\fR\fIdns\fR, \fB+\fR\fIip\fR
 Add a DNS name or IP address to the certificate\'s subject alternative names\.
+.
+.TP
+\fB+\fR\fIid\fR:\fIvalue\fR
+Add any SAN field to the certificate\'s subject alternative names, ie: URI:mailto:nobody@example\.com\.
 .
 .SH "THEME SONG"
 Led Zeppelin \- "Fool in the Rain"

--- a/share/man/man1/certified-csr.1.ronn
+++ b/share/man/man1/certified-csr.1.ronn
@@ -2,7 +2,7 @@
 
 ## SYNOPSIS
 
-`certified-csr` [`--bits`=_bits_] [`--ca`] [`--crl-url`=_crl-url_] [`--days`=_days_] [`--db`=_db_] [`--encrypt`] [`--issuer`=_issuer_] [`--issuer-name`=_issuer-name_] [`--name`=_name_] [`--ocsp-url`=_ocsp-url_] [`--password`=_password_] [`C`=_country_] [`ST`=_state_] [`L`=_locality_] [`O`=_organization_] [`OU`=_org-unit_] `CN`=_common-name_ [`+`_dns_[_..._]] [`+`_ip_[_..._]]
+`certified-csr` [`--bits`=_bits_] [`--ca`] [`--crl-url`=_crl-url_] [`--days`=_days_] [`--db`=_db_] [`--encrypt`] [`--issuer`=_issuer_] [`--issuer-name`=_issuer-name_] [`--name`=_name_] [`--ocsp-url`=_ocsp-url_] [`--password`=_password_] [`C`=_country_] [`ST`=_state_] [`L`=_locality_] [`O`=_organization_] [`OU`=_org-unit_] `CN`=_common-name_ [`+`_dns_[_..._]] [`+`_ip_[_..._]] [`+`_id_:_value_[_..._]]
 
 ## DESCRIPTION
 
@@ -48,6 +48,8 @@ Additional DNS names, including wildcards, and IP addresses can be added to the 
   Certificate common name (usually a domain name).
 * `+`_dns_, `+`_ip_:
   Add a DNS name or IP address to the certificate's subject alternative names.
+* `+`_id_:_value_:
+  Add any SAN field to the certificate's subject alternative names, ie: URI:mailto:nobody@example.com.
 
 ## THEME SONG
 

--- a/share/man/man1/certified.1
+++ b/share/man/man1/certified.1
@@ -1,13 +1,13 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "CERTIFIED" "1" "October 2015" "" "Certified"
+.TH "CERTIFIED" "1" "January 2017" "" "Certified"
 .
 .SH "NAME"
 \fBcertified\fR \- generate and sign certificates
 .
 .SH "SYNOPSIS"
-\fBcertified\fR [\fB\-\-bits\fR=\fIbits\fR] [\fB\-\-ca\fR] [\fB\-\-ca\-password\fR=\fIca\-password\fR] [\fB\-\-days\fR=\fIdays\fR] [\fB\-\-db\fR=\fIdb\fR] [\fB\-\-encrypt\fR] [\fB\-\-issuer\fR=\fIissuer\fR] [\fB\-\-issuer\-name\fR=\fIissuer\-name\fR] [\fB\-\-name\fR=\fIname\fR] [\fB\-\-no\-sign\fR] [\fB\-\-password\fR=\fIpassword\fR] [\fB\-\-revoke\fR] [\fB\-\-self\-signed\fR] [\fBC\fR=\fIcountry\fR] [\fBST\fR=\fIstate\fR] [\fBL\fR=\fIlocality\fR] [\fBO\fR=\fIorganization\fR] [\fBOU\fR=\fIorg\-unit\fR] \fBCN\fR=\fIcommon\-name\fR [\fB+\fR\fIdns\fR[\fI\.\.\.\fR]] [\fB+\fR\fIip\fR[\fI\.\.\.\fR]]
+\fBcertified\fR [\fB\-\-bits\fR=\fIbits\fR] [\fB\-\-ca\fR] [\fB\-\-ca\-password\fR=\fIca\-password\fR] [\fB\-\-days\fR=\fIdays\fR] [\fB\-\-db\fR=\fIdb\fR] [\fB\-\-encrypt\fR] [\fB\-\-issuer\fR=\fIissuer\fR] [\fB\-\-issuer\-name\fR=\fIissuer\-name\fR] [\fB\-\-name\fR=\fIname\fR] [\fB\-\-no\-sign\fR] [\fB\-\-password\fR=\fIpassword\fR] [\fB\-\-revoke\fR] [\fB\-\-self\-signed\fR] [\fBC\fR=\fIcountry\fR] [\fBST\fR=\fIstate\fR] [\fBL\fR=\fIlocality\fR] [\fBO\fR=\fIorganization\fR] [\fBOU\fR=\fIorg\-unit\fR] \fBCN\fR=\fIcommon\-name\fR [\fB+\fR\fIdns\fR[\fI\.\.\.\fR]] [\fB+\fR\fIip\fR[\fI\.\.\.\fR]] [\fB+\fR\fIid\fR:\fIvalue\fR[\fI\.\.\.\fR]]
 .
 .SH "DESCRIPTION"
 Generate and sign a certificate with the CA in \fIdb\fR unless \fB\-\-revoke\fR is given, in which case the certificate is revoked instead\.
@@ -96,6 +96,10 @@ Certificate common name (usually a domain name)\.
 .TP
 \fB+\fR\fIdns\fR, \fB+\fR\fIip\fR
 Add a DNS name or IP address to the certificate\'s subject alternative names\.
+.
+.TP
+\fB+\fR\fIid\fR:\fIvalue\fR
+Add any SAN field to the certificate\'s subject alternative names, ie: URI:mailto:nobody@example\.com\.
 .
 .SH "THEME SONG"
 Led Zeppelin \- "Fool in the Rain"

--- a/share/man/man1/certified.1.ronn
+++ b/share/man/man1/certified.1.ronn
@@ -2,7 +2,7 @@
 
 ## SYNOPSIS
 
-`certified` [`--bits`=_bits_] [`--ca`] [`--ca-password`=_ca-password_] [`--days`=_days_] [`--db`=_db_] [`--encrypt`] [`--issuer`=_issuer_] [`--issuer-name`=_issuer-name_] [`--name`=_name_] [`--no-sign`] [`--password`=_password_] [`--revoke`] [`--self-signed`] [`C`=_country_] [`ST`=_state_] [`L`=_locality_] [`O`=_organization_] [`OU`=_org-unit_] `CN`=_common-name_ [`+`_dns_[_..._]] [`+`_ip_[_..._]]
+`certified` [`--bits`=_bits_] [`--ca`] [`--ca-password`=_ca-password_] [`--days`=_days_] [`--db`=_db_] [`--encrypt`] [`--issuer`=_issuer_] [`--issuer-name`=_issuer-name_] [`--name`=_name_] [`--no-sign`] [`--password`=_password_] [`--revoke`] [`--self-signed`] [`C`=_country_] [`ST`=_state_] [`L`=_locality_] [`O`=_organization_] [`OU`=_org-unit_] `CN`=_common-name_ [`+`_dns_[_..._]] [`+`_ip_[_..._]] [`+`_id_:_value_[_..._]]
 
 ## DESCRIPTION
 
@@ -52,6 +52,8 @@ Additional DNS names, including wildcards, and IP addresses can be added to the 
   Certificate common name (usually a domain name).
 * `+`_dns_, `+`_ip_:
   Add a DNS name or IP address to the certificate's subject alternative names.
+* `+`_id_:_value_:
+  Add any SAN field to the certificate's subject alternative names, ie: URI:mailto:nobody@example.com.
 
 ## THEME SONG
 

--- a/test.sh
+++ b/test.sh
@@ -150,6 +150,11 @@ certified CN="Wildcard" +"*.example.com"
 openssl x509 -in "etc/ssl/certs/wildcard.crt" -noout -text |
 grep -F -q "DNS:*.example.com"
 
+# Test that we can add generic SAN IDs to a certificate.
+certified CN="AnySAN" +"URI:hello:world"
+openssl x509 -in "etc/ssl/certs/anysan.crt" -noout -text |
+grep -F -q "URI:hello:world"
+
 # Test that we can't add double DNS wildcards to a certificate.
 certified CN="Double Wildcard" +"*.*.example.com" && false
 


### PR DESCRIPTION
This would allow any SAN identifier to be added specifically without `certified` having to know about it. Would resolve #28 and #29