### PR TITLE
certified-csr should include req_extensions option

### DIFF
--- a/bin/certified-csr
+++ b/bin/certified-csr
@@ -141,6 +141,7 @@ default_bits = $BITS
 default_md = sha256
 distinguished_name = dn
 prompt = no
+req_extensions = x509_extensions
 EOF
     if [ "$SAN_DNS" -o "$SAN_IP" ]
     then cat <<EOF


### PR DESCRIPTION
need req_extensions = x509_extensions under [req] in order to properly add in [san] options